### PR TITLE
added ignore-feature + test + doc update

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://gumroad.com/l/hGYGh

--- a/Readme.md
+++ b/Readme.md
@@ -19,13 +19,14 @@
 
 ## API
 
-### throttle(fn, wait)
+### throttle(fn, wait, ignore)
 
 Creates a function that will call `fn` at most once every `wait` milliseconds.
 
 Supports leading and trailing invocation.
 
 `fn` will receive last context (`this`) and last arguments passed to a throttled wrapper before `fn` was invoked.
+`ignore` will disable trailing and ignore calls which come in too fast
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ module.exports = throttle;
  *
  * @param {Function} func Function to wrap.
  * @param {Number} wait Number of milliseconds that must elapse between `func` invocations.
+ * @param {Boolean} ignore processing calls which come in too fast
  * @return {Function} A new function that wraps the `func` function passed in.
  */
 
-function throttle (func, wait) {
+function throttle (func, wait, ignore) {
   var ctx, args, rtn, timeoutID; // caching
   var last = 0;
 
@@ -18,7 +19,10 @@ function throttle (func, wait) {
     var delta = new Date() - last;
     if (!timeoutID)
       if (delta >= wait) call();
-      else timeoutID = setTimeout(call, wait - delta);
+    else {
+      if( ignore ) return
+      timeoutID = setTimeout(call, wait - delta);
+    }
     return rtn;
   };
 

--- a/test.js
+++ b/test.js
@@ -70,4 +70,16 @@ describe('throttle', function(){
     }
   });
 
+  it('should fire only once', function(done){
+    var wait = 1000;
+    var calls = 0;
+    var fn = throttle(docall, wait, true);
+    fn.call(null, 1);
+    fn.call(null, 2);
+    assert(calls == 1);
+    done()
+    function docall() {
+      calls++
+    }
+  });
 });


### PR DESCRIPTION
this is handy because you don't always want trailing behaviour.
For instance, to prevent exceeding an remote api's ratelimiting policy
